### PR TITLE
ci: add macOS checks and fix EventKit isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: macos-15
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Check out the event commit
+        # This public repository needs no checkout action or stored credentials.
+        run: |
+          git init .
+          git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
+          git fetch --no-tags --depth=1 origin "$GITHUB_SHA"
+          git checkout --detach FETCH_HEAD
+
+      - name: Show toolchain
+        run: |
+          xcodebuild -version
+          swift --version
+
+      - name: Run the full test suite
+        run: swift test
+
+      - name: Build the release app and CLI
+        run: scripts/build-app.sh
+
+      - name: Verify the app bundle and smoke-test the CLI
+        run: |
+          plutil -lint dist/Fluegel.app/Contents/Info.plist
+          codesign --verify --deep --strict dist/Fluegel.app
+          test -x dist/Fluegel.app/Contents/MacOS/Fluegel
+          dist/fluegel --help
+
+          exit_code=0
+          output=$(dist/fluegel run -- relative-path 2>&1) || exit_code=$?
+          printf '%s\n' "$output"
+          test "$exit_code" -eq 2
+          test "$output" = 'usage: fluegel run -- /full/path [args...]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Fix Swift 6 builds with older EventKit SDK annotations by keeping Reminders permission requests on the main actor.

--- a/Sources/FluegelApp/PermissionManager.swift
+++ b/Sources/FluegelApp/PermissionManager.swift
@@ -27,15 +27,11 @@ final class PermissionManager: ObservableObject {
     func request(_ permission: PermissionKind) async -> PermissionStatus {
         switch permission {
         case .reminders:
-            let granted: Bool
-            do {
-                if #available(macOS 14.0, *) {
-                    granted = try await eventStore.requestFullAccessToReminders()
-                } else {
-                    granted = try await eventStore.requestAccess(to: .reminder)
+            // Keep the non-Sendable event store on the main actor; only return the result.
+            let granted = await withCheckedContinuation { continuation in
+                eventStore.requestFullAccessToReminders { granted, error in
+                    continuation.resume(returning: granted && error == nil)
                 }
-            } catch {
-                granted = false
             }
             remindersStatus = granted ? .authorized : Self.remindersStatus()
             return remindersStatus

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,6 +11,12 @@ The packaging script makes a release build, creates `dist/Fluegel.app`, copies t
 
 For local testing against saved privacy grants, sign the app with the same persistent signing identity used for that installation before launching it. Changing the bundle's signing identity may reset its TCC grants.
 
+## Continuous integration
+
+The `CI` workflow runs on branch pushes and pull requests using GitHub's `macos-15` runner and its bundled Swift toolchain. It runs the full test suite, builds the release app and CLI, verifies the app bundle's metadata and signature, and checks CLI help and rejection of relative executable paths. Pull requests test the merge commit with the target branch.
+
+The package has no external SwiftPM dependencies. CI uses the runner's existing tools without third-party actions. It does not launch the GUI app or request privacy permissions; launch and bridge checks still require local verification with the appropriate signing identity.
+
 ## Deploy to clawmac
 
 The repository includes a helper for the current clawmac deployment path:


### PR DESCRIPTION
Fluegel had no CI workflows or default-branch runs, and its actor-owned EventKit store failed to compile with the hosted runner’s SDK annotations. This fixes the permission-request isolation boundary and adds a macOS build-and-test workflow for branch pushes and pull requests, covering the complete test suite, release packaging, bundle verification, CLI help, and rejection of relative executable paths. Pull requests build the proposed merge commit. Development notes document the checks and the remaining local GUI verification.

Dependency audit: `swift package update` reports `Everything is already up-to-date`; `swift package show-dependencies` reports `No external dependencies found`. There are no other ecosystem manifests, lockfiles, or preexisting Actions pins to update. No major versions were taken or skipped, and no dependencies were added. The workflow uses native Git to fetch this public repository's exact event commit and the macOS runner's installed tools. A changelog entry records the source-build compatibility fix.

The permission manager now calls Apple’s completion-handler API on the main actor and bridges only the Boolean result through a checked continuation. This preserves denied/error handling without moving the non-Sendable event store across isolation domains, disabling concurrency checking, or adding unchecked Sendable conformance. The unreachable pre-macOS-14 fallback is removed because the package requires macOS 14+. See [Apple’s completion API](https://developer.apple.com/documentation/eventkit/ekeventstore/requestfullaccesstoreminders(completion:)).

### Local proof

On Apple Swift 6.4, both the full debug/test build and release packaging passed:

```text
$ swift package update
Everything is already up-to-date
$ swift package show-dependencies
No external dependencies found
$ swift test
Build complete! (14.03 sec)
✔ Test run with 5 tests in 1 suite passed after 2.226 seconds.
$ scripts/build-app.sh
Build complete! (8.47 sec)
/Users/steipete/Projects/fluegel/dist/Fluegel.app
/Users/steipete/Projects/fluegel/dist/fluegel
$ plutil -lint dist/Fluegel.app/Contents/Info.plist
dist/Fluegel.app/Contents/Info.plist: OK
$ codesign --verify --deep --strict dist/Fluegel.app
# exit 0, no output
$ actionlint .github/workflows/ci.yml
# exit 0, no output
$ dist/fluegel --help
fluegel status
fluegel run -- /full/path [args...]
fluegel allow list
fluegel allow add --path /full/path --permission reminders [--name name]
fluegel allow remove --path /full/path
fluegel permissions status reminders
fluegel permissions request reminders
fluegel audit list [--limit n]
$ dist/fluegel run -- relative-path
usage: fluegel run -- /full/path [args...]
# exit 2, as asserted by CI
```

For live proof, re-signed the newly built app with Peter's Developer ID, then launched it with an isolated application-data directory. Existing Fluegel data was preserved; no Reminders access or whitelist edits were requested.

```bash
codesign --force --deep --sign 'Developer ID Application: Peter Steinberger (Y5PE65HELJ)' dist/Fluegel.app
codesign --verify --deep --strict dist/Fluegel.app
open -g -n dist/Fluegel.app --env "CFFIXED_USER_HOME=$PWD/.build/h" --stdout "$PWD/.git/deps-refresh-20260830/app-fixed.stdout.log" --stderr "$PWD/.git/deps-refresh-20260830/app-fixed.stderr.log"
env CFFIXED_USER_HOME="$PWD/.build/h" dist/fluegel status
env CFFIXED_USER_HOME="$PWD/.build/h" dist/fluegel permissions status reminders
env CFFIXED_USER_HOME="$PWD/.build/h" dist/fluegel run -- /bin/echo fluegel-live-proof
env CFFIXED_USER_HOME="$PWD/.build/h" dist/fluegel audit list --limit 1
```

Actual output excerpts:

```text
ok
commands: 0
notDetermined
Command is not whitelisted: /bin/echo
# run exited 1, as expected
8/31/2026, 5:09:35 AM denied /bin/echo Command is not whitelisted: /bin/echo
```

Codex autoreview completed with `autoreview scoped-clean`, no accepted/actionable findings at its default P0 threshold.

### CI reasoning

Before: NOCI — GitHub returned zero workflows and no runs on `main`. This is a new build/test workflow, not an operations, scheduled, or production-monitoring job. It has read-only repository permissions and a 15-minute timeout. Hosted CI does not launch the GUI or request privacy permissions; the signed local app and bridge checks above provide that live proof.

The first hosted [push run](https://github.com/steipete/fluegel/actions/runs/33390060749) and [PR run](https://github.com/steipete/fluegel/actions/runs/33390072359) failed at compilation with `sending self.eventStore risks causing data races`. The newer local SDK accepted the original code, which is why hosted validation was necessary. The ownership fix above addresses the actual error; all tests and jobs remain enabled. The corrected [PR merge-commit run](https://github.com/steipete/fluegel/actions/runs/33390396854) passed its full build/test/package/smoke job. GitGuardian also passed. The corrected [push run](https://github.com/steipete/fluegel/actions/runs/33390391228) also passed. Both hosted build/test jobs are green at commit `c096e89`. Default-branch CI remains NOCI until this PR is merged by the maintainer/orchestrator; this worker will not merge it.
