### PR TITLE
fix: terminate surviving children after command timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## Unreleased
 
+- Fix timed-out commands leaving child processes running when their parent exits on SIGTERM.
 - Fix Swift 6 builds with older EventKit SDK annotations by keeping Reminders permission requests on the main actor.

--- a/Sources/FluegelCore/CommandRunner.swift
+++ b/Sources/FluegelCore/CommandRunner.swift
@@ -91,8 +91,10 @@ public struct CommandRunner: Sendable {
 
         if finished.wait(timeout: .now() + request.timeoutSeconds) == .timedOut {
             kill(-spawnedPID, SIGTERM)
-            if finished.wait(timeout: .now() + 2) == .timedOut {
-                kill(-spawnedPID, SIGKILL)
+            let parentFinished = finished.wait(timeout: .now() + 2)
+            // The parent can exit on SIGTERM while children in its group ignore it.
+            kill(-spawnedPID, SIGKILL)
+            if parentFinished == .timedOut {
                 _ = finished.wait(timeout: .now() + 2)
             }
             stdout.readabilityHandler = nil

--- a/Tests/FluegelCoreTests/FluegelCoreTests.swift
+++ b/Tests/FluegelCoreTests/FluegelCoreTests.swift
@@ -122,6 +122,54 @@ struct FluegelCoreTests {
         }
     }
 
+    @Test("command runner kills surviving children after the timed out parent exits")
+    func commandRunnerKillsChildAfterParentExits() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let childPidFile = directory.appendingPathComponent("child-pid")
+
+        defer {
+            if let contents = try? String(contentsOf: childPidFile, encoding: .utf8),
+               let pid = Int32(contents.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                kill(pid, SIGKILL)
+            }
+        }
+        // Reset the test host's inherited SIGTERM mask only inside the fixture.
+        #expect(throws: CommandRunnerError.timedOut) {
+            _ = try CommandRunner().run(RunRequest(
+                executablePath: "/usr/bin/perl",
+                arguments: [
+                    "-e",
+                    """
+                    use POSIX qw(SIG_UNBLOCK SIGTERM);
+                    $SIG{TERM} = 'DEFAULT';
+                    POSIX::sigprocmask(SIG_UNBLOCK, POSIX::SigSet->new(SIGTERM)) or die "sigprocmask: $!";
+                    defined(my $child = fork()) or die "fork: $!";
+                    if ($child == 0) {
+                        $SIG{TERM} = 'IGNORE';
+                        open(my $file, '>', $ARGV[0]) or die "pid file: $!";
+                        print $file "$$\\n";
+                        close($file);
+                    }
+                    sleep 30;
+                    """,
+                    childPidFile.path,
+                ],
+                timeoutSeconds: 2
+            ))
+        }
+
+        let childPID = try #require(Int32(
+            String(contentsOf: childPidFile, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
+        ))
+        // Orphan reaping can lag the signal delivery briefly.
+        let deadline = Date().addingTimeInterval(2)
+        while kill(childPID, 0) == 0 && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        #expect(kill(childPID, 0) == -1)
+    }
+
     private func temporaryDirectory() throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("FluegelTests-\(UUID().uuidString)", isDirectory: true)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,6 +33,8 @@ fluegel run -- /full/path [args...]
 
 The executable path must be absolute and match an enabled whitelist entry exactly. Arguments after the executable are passed through unchanged. The child process inherits Fluegel's environment, uses the CLI's current directory, and has a 30-second default timeout.
 
+On timeout, Fluegel sends SIGTERM to the command's process group, waits up to two seconds for the parent to exit, then sends SIGKILL to any remaining group members. Children that ignore SIGTERM are also stopped when their parent exits first.
+
 The separator is optional, but it makes the boundary between Fluegel's arguments and the child command clear.
 
 ## Whitelist


### PR DESCRIPTION
When a command times out, its parent can exit on SIGTERM while a child ignores that signal and continues running. Fluegel previously skipped SIGKILL as soon as it observed the parent exit. Always finish timeout escalation for the remaining process group, preserving the existing parent grace wait and public timeout behavior.

The regression starts a parent with normal SIGTERM handling and a child that ignores it. It fails against the original runner because the child stays alive, then passes with this fix. CLI documentation and the Unreleased changelog now describe the cleanup behavior.

Validation:
- `swift test --jobs 2 --no-parallel`: all 6 tests passed, including the new regression and existing large-output/timeout coverage.
- `swift build -c release --jobs 2` and `scripts/build-app.sh`: passed; app and CLI release metadata retain macOS 14.0 minimum.
- A separate native subprocess fixture linked against the release library confirmed surviving-child cleanup, stdout/stderr capture, and exit-code propagation.
- Personal Developer ID-signed app: live CLI status, whitelist list, denied execution, and audit checks passed using temporary app data; strict bundle verification passed.
- Independent Codex P0–P2 review: no actionable findings.

The maintenance audit found no external SwiftPM dependencies, third-party Actions, or pinned container/toolchain versions to update. Swift 6.0 and macOS 14 source/deployment requirements are unchanged.
